### PR TITLE
chore: add fw support

### DIFF
--- a/terraform-digitalocean-droplet/variables.tf
+++ b/terraform-digitalocean-droplet/variables.tf
@@ -1,3 +1,13 @@
+variable "inbound_rules" {
+  description = "Inbound rules for droplets"
+  type = list(object({
+    protocol          = string,
+    port              = string,
+    allowed_addresses = list(string)
+  }))
+  default = []
+}
+
 variable "name" {
   description = "Droplet Name"
   type        = string


### PR DESCRIPTION
Add fw support. Now we can pass in inbound rules to allow access to droplet. For example:

```
module "my_droplet" {
  source = "../../terraform-modules/terraform-digitalocean-droplet/"
  name = "my-droplet"
  inbound_rules = [ { protocol = "tcp", port = "22", allowed_addresses = [ "0.0.0.0/0" ]}]
}
```